### PR TITLE
refactor: consolidate emotion setters

### DIFF
--- a/lib/Views/Angry.dart
+++ b/lib/Views/Angry.dart
@@ -60,34 +60,12 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
     }
   }
 
-  void addFirstEmotion(String emotion) {
-    if (selectedemotions.isEmpty) {
-      selectedemotions.add(emotion);
-    } else {
-      selectedemotions[0] = emotion;
+  void setEmotion(int index, String emotion) {
+    if (selectedemotions.length <= index) {
+      selectedemotions.addAll(
+          List.filled(index - selectedemotions.length + 1, ''));
     }
-  }
-
-  void addSecondEmotion(String emotion) {
-    if (selectedemotions.length > 1) {
-      selectedemotions[1] = emotion;
-    } else {
-      selectedemotions.length == 0
-          ? selectedemotions.addAll([ "", emotion ])
-          : selectedemotions.add(emotion);
-    }
-  }
-
-  void addThirdEmotion(String emotion) {
-    if (selectedemotions.length > 2) {
-      selectedemotions[2] = emotion;
-    } else {
-      // eksik indeksleri doldur
-      while (selectedemotions.length < 2) {
-        selectedemotions.add("");
-      }
-      selectedemotions.add(emotion);
-    }
+    selectedemotions[index] = emotion;
   }
 
   void setLoading() {
@@ -239,7 +217,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             scwidht * 0.06,
                                 () {
                               selectedemotions.clear();
-                              addFirstEmotion(angryModel.kizgin);
+                              setEmotion(0, angryModel.kizgin);
                               setState(() {
                                 angryModel.toggleIsVisible1();
                                 if (angryModel.isVisible2) {
@@ -259,7 +237,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             10.58,
                             scwidht * 0.038,
                                 () {
-                              addSecondEmotion(angryModel.ofkeli);
+                              setEmotion(1, angryModel.ofkeli);
                               setState(() => angryModel.toggleIsVisible2());
                             },
                             angryModel.isVisible1,
@@ -272,7 +250,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             10.75,
                             scwidht * 0.038,
                                 () {
-                              addSecondEmotion(angryModel.rahatsizedilmis);
+                              setEmotion(1, angryModel.rahatsizedilmis);
                               setState(() => angryModel.toggleIsVisible2());
                             },
                             angryModel.isVisible1,
@@ -285,7 +263,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             10.88,
                             scwidht * 0.038,
                                 () {
-                              addSecondEmotion(angryModel.caniacimis);
+                              setEmotion(1, angryModel.caniacimis);
                               setState(() => angryModel.toggleIsVisible2());
                             },
                             angryModel.isVisible1,
@@ -298,7 +276,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             11.08,
                             scwidht * 0.038,
                                 () {
-                              addSecondEmotion(angryModel.nefretdolu);
+                              setEmotion(1, angryModel.nefretdolu);
                               setState(() => angryModel.toggleIsVisible2());
                             },
                             angryModel.isVisible1,
@@ -311,7 +289,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             11.20,
                             scwidht * 0.038,
                                 () {
-                              addSecondEmotion(angryModel.huysuz);
+                              setEmotion(1, angryModel.huysuz);
                               setState(() => angryModel.toggleIsVisible2());
                             },
                             angryModel.isVisible1,
@@ -324,7 +302,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             11.4,
                             scwidht * 0.038,
                                 () {
-                              addSecondEmotion(angryModel.kiskanc);
+                              setEmotion(1, angryModel.kiskanc);
                               setState(() => angryModel.toggleIsVisible2());
                             },
                             angryModel.isVisible1,
@@ -339,7 +317,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             10.56,
                             scwidht * 0.038,
                                 () async {
-                              addThirdEmotion(angryModel.agresif);
+                              setEmotion(2, angryModel.agresif);
                               Requests().sendSelectedEmotions(widget.id, selectedemotions);
                               setState(() {});
                               await _ensureDescriptionLoaded();
@@ -356,7 +334,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             10.70,
                             scwidht * 0.040,
                                 () async {
-                              addThirdEmotion(angryModel.agirlikcokmus);
+                              setEmotion(2, angryModel.agirlikcokmus);
                               Requests().sendSelectedEmotions(widget.id, selectedemotions);
                               setState(() {});
                               await _ensureDescriptionLoaded();
@@ -373,7 +351,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             10.82,
                             scwidht * 0.040,
                                 () async {
-                              addThirdEmotion(angryModel.igrenmis);
+                              setEmotion(2, angryModel.igrenmis);
                               Requests().sendSelectedEmotions(widget.id, selectedemotions);
                               setState(() {});
                               await _ensureDescriptionLoaded();
@@ -390,7 +368,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             11.05,
                             scwidht * 0.040,
                                 () async {
-                              addThirdEmotion(angryModel.husranaugramis);
+                              setEmotion(2, angryModel.husranaugramis);
                               Requests().sendSelectedEmotions(widget.id, selectedemotions);
                               setState(() {});
                               await _ensureDescriptionLoaded();
@@ -407,7 +385,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             11.2,
                             scwidht * 0.040,
                                 () async {
-                              addThirdEmotion(angryModel.dusmanca);
+                              setEmotion(2, angryModel.dusmanca);
                               Requests().sendSelectedEmotions(widget.id, selectedemotions);
                               setState(() {});
                               await _ensureDescriptionLoaded();
@@ -424,7 +402,7 @@ class _ScaredState extends State<Angry> with WidgetsBindingObserver {
                             11.40,
                             scwidht * 0.040,
                                 () async {
-                              addThirdEmotion(angryModel.rahatsizlikduymus);
+                              setEmotion(2, angryModel.rahatsizlikduymus);
                               Requests().sendSelectedEmotions(widget.id, selectedemotions);
                               setState(() {});
                               await _ensureDescriptionLoaded();

--- a/lib/Views/Calm.dart
+++ b/lib/Views/Calm.dart
@@ -65,26 +65,12 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
     }
   }
 
-  void addFirstEmotion(String emotion) {
-    selectedemotions.insert(0, emotion);
-  }
-
-  void addSecondEmotion(String emotion) {
-    if (selectedemotions.length > 1) {
-      selectedemotions[1] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          1, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
+  void setEmotion(int index, String emotion) {
+    if (selectedemotions.length <= index) {
+      selectedemotions.addAll(
+          List.filled(index - selectedemotions.length + 1, ''));
     }
-  }
-
-  void addThirdEmotion(String emotion) {
-    if (selectedemotions.length > 2) {
-      selectedemotions[2] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          2, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
-    }
+    selectedemotions[index] = emotion;
   }
 
   void _loadImages() async {
@@ -292,7 +278,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               0,
                               scwidht * 0.06, () {
                             selectedemotions.clear();
-                            addFirstEmotion(calmModel.sakin);
+                            setEmotion(0, calmModel.sakin);
                             setState(() {
                               calmModel.toggleIsVisible1();
 
@@ -312,7 +298,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.66,
                               10.58,
                               scwidht * 0.038, () {
-                            addSecondEmotion(calmModel.rahatlamis);
+                            setEmotion(1, calmModel.rahatlamis);
                             setState(() {
                               calmModel.toggleIsVisible2();
                             });
@@ -324,7 +310,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.63,
                               10.70,
                               scwidht * 0.038, () {
-                            addSecondEmotion(calmModel.yumusamis);
+                            setEmotion(1, calmModel.yumusamis);
                             setState(() {
                               calmModel.toggleIsVisible2();
                             });
@@ -336,7 +322,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.64,
                               10.85,
                               scwidht * 0.038, () {
-                            addSecondEmotion(calmModel.guvende);
+                            setEmotion(1, calmModel.guvende);
                             setState(() {
                               calmModel.toggleIsVisible2();
                             });
@@ -348,7 +334,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.67,
                               11,
                               scwidht * 0.038, () {
-                            addSecondEmotion(calmModel.aktif);
+                            setEmotion(1, calmModel.aktif);
                             setState(() {
                               calmModel.toggleIsVisible2();
                             });
@@ -360,7 +346,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.618,
                               11.25,
                               scwidht * 0.038, () {
-                            addSecondEmotion(calmModel.odaklanmis);
+                            setEmotion(1, calmModel.odaklanmis);
                             setState(() {
                               calmModel.toggleIsVisible2();
                             });
@@ -373,7 +359,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.66,
                               11.42,
                               scwidht * 0.038, () {
-                            addSecondEmotion(calmModel.konforda);
+                            setEmotion(1, calmModel.konforda);
                             setState(() {
                               calmModel.toggleIsVisible2();
                             });
@@ -389,7 +375,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.36,
                               10.55,
                               scwidht * 0.038, () {
-                            addThirdEmotion(calmModel.bariscil);
+                            setEmotion(2, calmModel.bariscil);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});
@@ -402,7 +388,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.25,
                               10.70,
                               scwidht * 0.040, () {
-                            addThirdEmotion(calmModel.rahatlikicinde);
+                            setEmotion(2, calmModel.rahatlikicinde);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});
@@ -415,7 +401,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.28,
                               10.85,
                               scwidht * 0.040, () {
-                            addThirdEmotion(calmModel.duygusal);
+                            setEmotion(2, calmModel.duygusal);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});
@@ -428,7 +414,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.19,
                               11.10,
                               scwidht * 0.040, () {
-                            addThirdEmotion(calmModel.halindenmenun);
+                            setEmotion(2, calmModel.halindenmenun);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});
@@ -441,7 +427,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.32,
                               11.3,
                               scwidht * 0.040, () {
-                            addThirdEmotion(calmModel.iyimser);
+                            setEmotion(2, calmModel.iyimser);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});
@@ -454,7 +440,7 @@ class _StrongState extends State<Calm> with WidgetsBindingObserver {
                               scwidht * 0.31,
                               11.42,
                               scwidht * 0.040, () {
-                            addThirdEmotion(calmModel.kabullenmis);
+                            setEmotion(2, calmModel.kabullenmis);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});

--- a/lib/Views/Happy.dart
+++ b/lib/Views/Happy.dart
@@ -61,26 +61,12 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
     }
   }
 
-  void addFirstEmotion(String emotion) {
-    selectedemotions.insert(0, emotion);
-  }
-
-  void addSecondEmotion(String emotion) {
-    if (selectedemotions.length > 1) {
-      selectedemotions[1] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          1, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
+  void setEmotion(int index, String emotion) {
+    if (selectedemotions.length <= index) {
+      selectedemotions.addAll(
+          List.filled(index - selectedemotions.length + 1, ''));
     }
-  }
-
-  void addThirdEmotion(String emotion) {
-    if (selectedemotions.length > 2) {
-      selectedemotions[2] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          2, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
-    }
+    selectedemotions[index] = emotion;
   }
 
   void _loadImages() async {
@@ -287,7 +273,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 0,
                                 scwidht * 0.06, () {
                               selectedemotions.clear();
-                              addFirstEmotion(happymodel.mutlu);
+                              setEmotion(0, happymodel.mutlu);
                               setState(() {
                                 happymodel.toggleIsVisible1();
                                 if (happymodel.isVisible2 == true) {
@@ -303,7 +289,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.70,
                                 10.58,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(happymodel.neseli);
+                              setEmotion(1, happymodel.neseli);
                               setState(() {
                                 happymodel.toggleIsVisible2();
                               });
@@ -315,7 +301,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.675,
                                 10.70,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(happymodel.keyifli);
+                              setEmotion(1, happymodel.keyifli);
                               setState(() {
                                 happymodel.toggleIsVisible2();
                               });
@@ -327,7 +313,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.62,
                                 10.85,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(happymodel.zevkalmis);
+                              setEmotion(1, happymodel.zevkalmis);
                               setState(() {
                                 happymodel.toggleIsVisible2();
                               });
@@ -339,7 +325,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.638,
                                 11.05,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(happymodel.sevinmis);
+                              setEmotion(1, happymodel.sevinmis);
                               setState(() {
                                 happymodel.toggleIsVisible2();
                               });
@@ -351,7 +337,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.645,
                                 11.20,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(happymodel.eglenmis);
+                              setEmotion(1, happymodel.eglenmis);
                               setState(() {
                                 happymodel.toggleIsVisible2();
                               });
@@ -363,7 +349,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.645,
                                 11.38,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(happymodel.nesesacan);
+                              setEmotion(1, happymodel.nesesacan);
                               setState(() {
                                 happymodel.toggleIsVisible2();
                               });
@@ -376,7 +362,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.32,
                                 10.56,
                                 scwidht * 0.038, () {
-                              addThirdEmotion(happymodel.memnun);
+                              setEmotion(2, happymodel.memnun);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});
@@ -390,7 +376,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.23,
                                 10.70,
                                 scwidht * 0.040, () {
-                              addThirdEmotion(happymodel.cokeglenmis);
+                              setEmotion(2, happymodel.cokeglenmis);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});
@@ -403,7 +389,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.26,
                                 10.90,
                                 scwidht * 0.040, () {
-                              addThirdEmotion(happymodel.hevesli);
+                              setEmotion(2, happymodel.hevesli);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});
@@ -416,7 +402,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.19,
                                 11.05,
                                 scwidht * 0.040, () {
-                              addThirdEmotion(happymodel.hosnutolmus);
+                              setEmotion(2, happymodel.hosnutolmus);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});
@@ -429,7 +415,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.25,
                                 11.25,
                                 scwidht * 0.040, () {
-                              addThirdEmotion(happymodel.heyecanli);
+                              setEmotion(2, happymodel.heyecanli);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});
@@ -442,7 +428,7 @@ class _HappyState extends State<Happy> with WidgetsBindingObserver {
                                 scwidht * 0.305,
                                 11.40,
                                 scwidht * 0.040, () {
-                              addThirdEmotion(happymodel.tutkulu);
+                              setEmotion(2, happymodel.tutkulu);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});

--- a/lib/Views/Sad.dart
+++ b/lib/Views/Sad.dart
@@ -60,26 +60,12 @@ class _SadState extends State<Sad> with WidgetsBindingObserver {
   }
 
 
-  void addFirstEmotion(String emotion) {
-    selectedemotions.insert(0, emotion);
-  }
-
-  void addSecondEmotion(String emotion) {
-    if (selectedemotions.length > 1) {
-      selectedemotions[1] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          1, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
+  void setEmotion(int index, String emotion) {
+    if (selectedemotions.length <= index) {
+      selectedemotions.addAll(
+          List.filled(index - selectedemotions.length + 1, ''));
     }
-  }
-
-  void addThirdEmotion(String emotion) {
-    if (selectedemotions.length > 2) {
-      selectedemotions[2] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          2, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
-    }
+    selectedemotions[index] = emotion;
   }
 
   void _loadImages() async {
@@ -275,7 +261,7 @@ class _SadState extends State<Sad> with WidgetsBindingObserver {
                       _buildEmotionButton(context, sadmodel.uzgun, scwidht * 0.350,
                           scwidht * 0.835, 0, scwidht * 0.06, () {
                             selectedemotions.clear();
-                            addFirstEmotion(sadmodel.uzgun);
+                            setEmotion(0, sadmodel.uzgun);
                             setState(() {
                               sadmodel.toggleIsVisible1();
                               if (sadmodel.isVisible2 == true) {
@@ -286,42 +272,42 @@ class _SadState extends State<Sad> with WidgetsBindingObserver {
                       //2.PARÇA DUYGULARI
                       _buildEmotionButton(context, sadmodel.incinmis, scwidht * 0.19,
                           scwidht * 0.68, 10.58, scwidht * 0.038, () {
-                            addSecondEmotion(sadmodel.incinmis);
+                            setEmotion(1, sadmodel.incinmis);
                             setState(() {
                               sadmodel.toggleIsVisible2();
                             });
                           }, sadmodel.isVisible1),
                       _buildEmotionButton(context, sadmodel.zayif, scwidht * 0.295,
                           scwidht * 0.69, 10.70, scwidht * 0.038, () {
-                            addSecondEmotion(sadmodel.zayif);
+                            setEmotion(1, sadmodel.zayif);
                             setState(() {
                               sadmodel.toggleIsVisible2();
                             });
                           }, sadmodel.isVisible1),
                       _buildEmotionButton(context, sadmodel.yalniz, scwidht * 0.35,
                           scwidht * 0.67, 10.85, scwidht * 0.038, () {
-                            addSecondEmotion(sadmodel.yalniz);
+                            setEmotion(1, sadmodel.yalniz);
                             setState(() {
                               sadmodel.toggleIsVisible2();
                             });
                           }, sadmodel.isVisible1),
                       _buildEmotionButton(context, sadmodel.bakimsiz, scwidht * 0.395,
                           scwidht * 0.645, 11.05, scwidht * 0.038, () {
-                            addSecondEmotion(sadmodel.bakimsiz);
+                            setEmotion(1, sadmodel.bakimsiz);
                             setState(() {
                               sadmodel.toggleIsVisible2();
                             });
                           }, sadmodel.isVisible1),
                       _buildEmotionButton(context, sadmodel.utanmis, scwidht * 0.47,
                           scwidht * 0.66, 11.20, scwidht * 0.038, () {
-                            addSecondEmotion(sadmodel.utanmis);
+                            setEmotion(1, sadmodel.utanmis);
                             setState(() {
                               sadmodel.toggleIsVisible2();
                             });
                           }, sadmodel.isVisible1),
                       _buildEmotionButton(context, sadmodel.izoleolmus, scwidht * 0.52,
                           scwidht * 0.65, 11.4, scwidht * 0.038, () {
-                            addSecondEmotion(sadmodel.izoleolmus);
+                            setEmotion(1, sadmodel.izoleolmus);
                             setState(() {
                               sadmodel.toggleIsVisible2();
                             });
@@ -329,7 +315,7 @@ class _SadState extends State<Sad> with WidgetsBindingObserver {
                       //3. PARÇA DUYGULARI
                       _buildEmotionButton(context, sadmodel.hayal, scwidht * 0,
                           scwidht * 0.26, 10.56, scwidht * 0.038, () {
-                            addThirdEmotion(sadmodel.hayal);
+                            setEmotion(2, sadmodel.hayal);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});
@@ -344,7 +330,7 @@ class _SadState extends State<Sad> with WidgetsBindingObserver {
                           scwidht * 0.24,
                           10.70,
                           scwidht * 0.040, () {
-                        addThirdEmotion(sadmodel.motivasyonsuz);
+                        setEmotion(2, sadmodel.motivasyonsuz);
                         Requests().sendSelectedEmotions(
                             widget.id, selectedemotions);
                         setState(() {});
@@ -353,7 +339,7 @@ class _SadState extends State<Sad> with WidgetsBindingObserver {
                       },sadmodel.isVisible2),
                       _buildEmotionButton(context, sadmodel.umutsuz, scwidht * 0.32,
                           scwidht * 0.27, 10.90, scwidht * 0.040, () {
-                            addThirdEmotion(sadmodel.umutsuz);
+                            setEmotion(2, sadmodel.umutsuz);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});
@@ -367,7 +353,7 @@ class _SadState extends State<Sad> with WidgetsBindingObserver {
                           scwidht * 0.20,
                           11.05,
                           scwidht * 0.040, () {
-                        addThirdEmotion(sadmodel.ihaneteugramis);
+                        setEmotion(2, sadmodel.ihaneteugramis);
                         Requests().sendSelectedEmotions(
                             widget.id, selectedemotions);
                         setState(() {});
@@ -376,7 +362,7 @@ class _SadState extends State<Sad> with WidgetsBindingObserver {
                       },sadmodel.isVisible2),
                       _buildEmotionButton(context, sadmodel.umitduymayan, scwidht * 0.51,
                           scwidht * 0.23, 11.3, scwidht * 0.040, () {
-                            addThirdEmotion(sadmodel.umitduymayan);
+                            setEmotion(2, sadmodel.umitduymayan);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});
@@ -385,7 +371,7 @@ class _SadState extends State<Sad> with WidgetsBindingObserver {
                           },sadmodel.isVisible2),
                       _buildEmotionButton(context, sadmodel.reddedilmis, scwidht * 0.65,
                           scwidht * 0.30, 11.40, scwidht * 0.040, () {
-                            addThirdEmotion(sadmodel.reddedilmis);
+                            setEmotion(2, sadmodel.reddedilmis);
                             Requests().sendSelectedEmotions(
                                 widget.id, selectedemotions);
                             setState(() {});

--- a/lib/Views/Scared.dart
+++ b/lib/Views/Scared.dart
@@ -61,26 +61,12 @@ class _ScaredState extends State<Scared> with WidgetsBindingObserver {
   }
 
 
-  void addFirstEmotion(String emotion) {
-    selectedemotions.insert(0, emotion);
-  }
-
-  void addSecondEmotion(String emotion) {
-    if (selectedemotions.length > 1) {
-      selectedemotions[1] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          1, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
+  void setEmotion(int index, String emotion) {
+    if (selectedemotions.length <= index) {
+      selectedemotions.addAll(
+          List.filled(index - selectedemotions.length + 1, ''));
     }
-  }
-
-  void addThirdEmotion(String emotion) {
-    if (selectedemotions.length > 2) {
-      selectedemotions[2] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          2, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
-    }
+    selectedemotions[index] = emotion;
   }
 
   void _loadImages() async {
@@ -280,7 +266,7 @@ class _ScaredState extends State<Scared> with WidgetsBindingObserver {
                             _buildEmotionButton(context, scaredmodel.korkmus, scwidht * 0.345,
                                 scwidht * 0.835, 0, scwidht * 0.045, () {
                                   selectedemotions.clear();
-                                  addFirstEmotion(scaredmodel.korkmus);
+                                  setEmotion(0, scaredmodel.korkmus);
                                   setState(() {
                                     scaredmodel.toggleIsVisible1();
                                     if (scaredmodel.isVisible2 == true) {
@@ -291,42 +277,42 @@ class _ScaredState extends State<Scared> with WidgetsBindingObserver {
                             //2.PARÇA DUYGULARI
                             _buildEmotionButton(context, scaredmodel.guvensiz, scwidht * 0.185,
                                 scwidht * 0.68, 10.58, scwidht * 0.038, () {
-                                  addSecondEmotion(scaredmodel.guvensiz);
+                                  setEmotion(1, scaredmodel.guvensiz);
                                   setState(() {
                                     scaredmodel.toggleIsVisible2();
                                   });
                                 }, scaredmodel.isVisible1),
                             _buildEmotionButton(context, scaredmodel.gergin, scwidht * 0.278,
                                 scwidht * 0.68, 10.70, scwidht * 0.038, () {
-                                  addSecondEmotion(scaredmodel.gergin);
+                                  setEmotion(1, scaredmodel.gergin);
                                   setState(() {
                                     scaredmodel.toggleIsVisible2();
                                   });
                                 }, scaredmodel.isVisible1),
                             _buildEmotionButton(context, scaredmodel.panikicinde, scwidht * 0.297,
                                 scwidht * 0.62, 10.86, scwidht * 0.038, () {
-                                  addSecondEmotion(scaredmodel.panikicinde);
+                                  setEmotion(1, scaredmodel.panikicinde);
                                   setState(() {
                                     scaredmodel.toggleIsVisible2();
                                   });
                                 }, scaredmodel.isVisible1),
                             _buildEmotionButton(context, scaredmodel.endiseli, scwidht * 0.415,
                                 scwidht * 0.655, 11.05, scwidht * 0.038, () {
-                                  addSecondEmotion(scaredmodel.endiseli);
+                                  setEmotion(1, scaredmodel.endiseli);
                                   setState(() {
                                     scaredmodel.toggleIsVisible2();
                                   });
                                 }, scaredmodel.isVisible1),
                             _buildEmotionButton(context, scaredmodel.sokolmus, scwidht * 0.46,
                                 scwidht * 0.635, 11.20, scwidht * 0.038, () {
-                                  addSecondEmotion(scaredmodel.sokolmus);
+                                  setEmotion(1, scaredmodel.sokolmus);
                                   setState(() {
                                     scaredmodel.toggleIsVisible2();
                                   });
                                 }, scaredmodel.isVisible1),
                             _buildEmotionButton(context, scaredmodel.stresli, scwidht * 0.562,
                                 scwidht * 0.69, 11.39, scwidht * 0.038, () {
-                                  addSecondEmotion(scaredmodel.stresli);
+                                  setEmotion(1, scaredmodel.stresli);
                                   setState(() {
                                     scaredmodel.toggleIsVisible2();
                                   });
@@ -334,7 +320,7 @@ class _ScaredState extends State<Scared> with WidgetsBindingObserver {
                             //3. PARÇA DUYGULARI
                             _buildEmotionButton(context, scaredmodel.kaygicinde, scwidht * 0,
                                 scwidht * 0.29, 10.56, scwidht * 0.038, () {
-                                  addThirdEmotion(scaredmodel.kaygicinde);
+                                  setEmotion(2, scaredmodel.kaygicinde);
                                   Requests().sendSelectedEmotions(
                                       widget.id, selectedemotions);
                                   setState(() {});
@@ -344,7 +330,7 @@ class _ScaredState extends State<Scared> with WidgetsBindingObserver {
 
                             _buildEmotionButton(context, scaredmodel.supheicinde, scwidht * 0.10,
                                 scwidht * 0.225, 10.65, scwidht * 0.040, () {
-                                  addThirdEmotion(scaredmodel.supheicinde);
+                                  setEmotion(2, scaredmodel.supheicinde);
                                   Requests().sendSelectedEmotions(
                                       widget.id, selectedemotions);
                                   setState(() {
@@ -353,7 +339,7 @@ class _ScaredState extends State<Scared> with WidgetsBindingObserver {
                                 }, scaredmodel.isVisible2),
                             _buildEmotionButton(context, scaredmodel.ezilmis, scwidht * 0.30,
                                 scwidht * 0.25, 10.85, scwidht * 0.040, () {
-                                  addThirdEmotion(scaredmodel.ezilmis);
+                                  setEmotion(2, scaredmodel.ezilmis);
                                   Requests().sendSelectedEmotions(
                                       widget.id, selectedemotions);
                                   setState(() {});
@@ -367,7 +353,7 @@ class _ScaredState extends State<Scared> with WidgetsBindingObserver {
                                 scwidht * 0.17,
                                 11.04,
                                 scwidht * 0.040, () {
-                              addThirdEmotion(scaredmodel.heyecandangerilmis);
+                              setEmotion(2, scaredmodel.heyecandangerilmis);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});
@@ -376,7 +362,7 @@ class _ScaredState extends State<Scared> with WidgetsBindingObserver {
                             },  scaredmodel.isVisible2),
                             _buildEmotionButton(context, scaredmodel.paranoya, scwidht * 0.565,
                                 scwidht * 0.25, 11.20, scwidht * 0.040, () {
-                                  addThirdEmotion(scaredmodel.paranoya);
+                                  setEmotion(2, scaredmodel.paranoya);
                                   Requests().sendSelectedEmotions(
                                       widget.id, selectedemotions);
                                   setState(() {});
@@ -385,7 +371,7 @@ class _ScaredState extends State<Scared> with WidgetsBindingObserver {
                                 },  scaredmodel.isVisible2),
                             _buildEmotionButton(context, scaredmodel.kafasikarisik, scwidht * 0.641,
                                 scwidht * 0.25, 11.40, scwidht * 0.040, () {
-                                  addThirdEmotion(scaredmodel.kafasikarisik);
+                                  setEmotion(2, scaredmodel.kafasikarisik);
                                   Requests().sendSelectedEmotions(
                                       widget.id, selectedemotions);
                                   print(selectedemotions.toString());

--- a/lib/Views/Strong.dart
+++ b/lib/Views/Strong.dart
@@ -63,26 +63,12 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
     }
   }
 
-  void addFirstEmotion(String emotion) {
-    selectedemotions.insert(0, emotion);
-  }
-
-  void addSecondEmotion(String emotion) {
-    if (selectedemotions.length > 1) {
-      selectedemotions[1] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          1, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
+  void setEmotion(int index, String emotion) {
+    if (selectedemotions.length <= index) {
+      selectedemotions.addAll(
+          List.filled(index - selectedemotions.length + 1, ''));
     }
-  }
-
-  void addThirdEmotion(String emotion) {
-    if (selectedemotions.length > 2) {
-      selectedemotions[2] = emotion; // 1. index'teki öğeyi değiştir
-    } else {
-      selectedemotions.insert(
-          2, emotion); // Eğer 1. index'te öğe yoksa, yeni öğeyi ekle
-    }
+    selectedemotions[index] = emotion;
   }
 
   void _loadImages() async {
@@ -285,7 +271,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                             _buildEmotionButton(context, strongmodel.guclu, scwidht * 0.350,
                                 scwidht * 0.835, 0, scwidht * 0.06, () {
                                   selectedemotions.clear();
-                                  addFirstEmotion(strongmodel.guclu);
+                                  setEmotion(0, strongmodel.guclu);
                                   setState(() {
                                     strongmodel.toggleIsVisible1();
                                     if (strongmodel.isVisible2 == true) {
@@ -301,7 +287,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 scwidht * 0.64,
                                 10.58,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(strongmodel.gururduymus);
+                              setEmotion(1, strongmodel.gururduymus);
                               setState(() {
                                 strongmodel.toggleIsVisible2();
                               });
@@ -313,7 +299,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 scwidht * 0.65,
                                 10.70,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(strongmodel.gucsahibi);
+                              setEmotion(1, strongmodel.gucsahibi);
                               setState(() {
                                 strongmodel.toggleIsVisible2();
                               });
@@ -325,7 +311,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 scwidht * 0.67,
                                 10.85,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(strongmodel.saygin);
+                              setEmotion(1, strongmodel.saygin);
                               setState(() {
                                 strongmodel.toggleIsVisible2();
                               });
@@ -337,7 +323,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 scwidht * 0.665,
                                 11.08,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(strongmodel.degerli);
+                              setEmotion(1, strongmodel.degerli);
                               setState(() {
                                 strongmodel.toggleIsVisible2();
                               });
@@ -349,7 +335,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 scwidht * 0.645,
                                 11.20,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(strongmodel.saygideger);
+                              setEmotion(1, strongmodel.saygideger);
                               setState(() {
                                 strongmodel.toggleIsVisible2();
                               });
@@ -361,7 +347,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 scwidht * 0.675,
                                 11.4,
                                 scwidht * 0.038, () {
-                              addSecondEmotion(strongmodel.korkusuz);
+                              setEmotion(1, strongmodel.korkusuz);
                               setState(() {
                                 strongmodel.toggleIsVisible2();
                               });
@@ -369,7 +355,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                             //3. PARÇA DUYGULARI
                             _buildEmotionButton(context, strongmodel.onemli, scwidht * 0.10,
                                 scwidht * 0.25, 10.7, scwidht * 0.038, () {
-                                  addThirdEmotion(strongmodel.onemli);
+                                  setEmotion(2, strongmodel.onemli);
                                   Requests().sendSelectedEmotions(
                                       widget.id, selectedemotions);
                                   setState(() {});
@@ -377,7 +363,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 }, strongmodel.isVisible2),
                             _buildEmotionButton(context, strongmodel.azimli, scwidht * 0.11,
                                 scwidht * 0.36, 10.60, scwidht * 0.040, () {
-                                  addThirdEmotion(strongmodel.azimli);
+                                  setEmotion(2, strongmodel.azimli);
                                   Requests().sendSelectedEmotions(
                                       widget.id, selectedemotions);
                                   setState(() {});
@@ -390,7 +376,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 scwidht * 0.22,
                                 10.85,
                                 scwidht * 0.040, () {
-                              addThirdEmotion(strongmodel.guclenmisgibi);
+                              setEmotion(2, strongmodel.guclenmisgibi);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});
@@ -403,7 +389,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 scwidht * 0.29,
                                 11.05,
                                 scwidht * 0.040, () {
-                              addThirdEmotion(strongmodel.basarili);
+                              setEmotion(2, strongmodel.basarili);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});
@@ -411,7 +397,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                             }, strongmodel.isVisible2),
                             _buildEmotionButton(context, strongmodel.zeki, scwidht * 0.56,
                                 scwidht * 0.33, 11.3, scwidht * 0.040, () {
-                                  addThirdEmotion(strongmodel.zeki);
+                                  setEmotion(2, strongmodel.zeki);
                                   Requests().sendSelectedEmotions(
                                       widget.id, selectedemotions);
                                   setState(() {});
@@ -424,7 +410,7 @@ class _StrongState extends State<Strong> with WidgetsBindingObserver {
                                 scwidht * 0.26,
                                 11.40,
                                 scwidht * 0.040, () {
-                              addThirdEmotion(strongmodel.kendindenemin);
+                              setEmotion(2, strongmodel.kendindenemin);
                               Requests().sendSelectedEmotions(
                                   widget.id, selectedemotions);
                               setState(() {});


### PR DESCRIPTION
## Summary
- replace addFirstEmotion/addSecondEmotion/addThirdEmotion with generic setEmotion across emotion screens
- automatically grow selectedemotions list when setting by index

## Testing
- `flutter test` *(command not found)*
- `dart test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bc57a1621883328a027296d3d88da5